### PR TITLE
Update PrepText.R

### DIFF
--- a/R/PrepText.R
+++ b/R/PrepText.R
@@ -44,7 +44,7 @@ PrepText <- function(textdata, groupvar, textvar, node_type = c("groups","words"
     
     textdata_tokens <- as_tibble(textdata) %>%
       select(groupvar, textvar) %>%
-      unnest_tokens_(output = "word", input = textvar, token = tokenizer, ...)
+      unnest_tokens(output = "word", input = textvar, token = tokenizer, ...)
     
     # get part of speech with udpipe
     # annotate for pos only w/ pre-tokenized data
@@ -64,11 +64,11 @@ PrepText <- function(textdata, groupvar, textvar, node_type = c("groups","words"
     # we use tidytext to flexibly tokenize words or tweets
     textdata_tokens <- as_tibble(textdata) %>%
       select(groupvar, textvar) %>%
-      unnest_tokens_(output = "word", input = textvar, token = tokenizer, strip_punct = FALSE, ...)
+      unnest_tokens(output = "word", input = textvar, token = tokenizer, strip_punct = FALSE, ...)
     
     # then we prepare the tokenized documents for dependency parsing
     textdata_tokens <- textdata_tokens %>% 
-      group_by_(groupvar) %>% 
+      group_by(groupvar) %>% 
       summarise(documents = paste(word, collapse = "\n"))
     
     # parse dependencies with udpipe
@@ -126,7 +126,7 @@ PrepText <- function(textdata, groupvar, textvar, node_type = c("groups","words"
   if (node_type=="groups"){
     # count terms by group
     textdata <- textdata %>%
-      group_by_(groupvar) %>%
+      group_by(groupvar) %>%
       count(lemma) %>%
       rename(count = n)
   }


### PR DESCRIPTION
The following warning messages have been fixed 

Warning messages:
1: 'unnest_tokens_' is deprecated.
Use 'unnest_tokens' instead.
See help("Deprecated")
2: `group_by_()` is deprecated as of dplyr 0.7.0.
Please use `group_by()` instead.
See vignette('programming') for more help