### PR TITLE
fix encoding error in PrepText on Windows systems

### DIFF
--- a/R/PrepText.R
+++ b/R/PrepText.R
@@ -21,7 +21,7 @@ PrepText <- function(textdata, groupvar, textvar, node_type = c("groups","words"
                     ...) {
   
   # remove non-UTF8 characters
-  textdata[[textvar]] <- iconv(textdata[[textvar]],  to="UTF-8", sub='')
+  textdata[[textvar]] <- iconv(textdata[[textvar]], from="UTF-8", to="UTF-8", sub='')
   
   # remove emojis, symbols, and meta characters from tweets
   if (tokenizer=="tweets") {


### PR DESCRIPTION
The attempt to remove non-UTF-8 characters from the text data creates problems on Windows machines. If no ``from`` encoding is specified in ``iconv`` it assumes the system standard. This works on Linux and Mac but not on Windows. If the data is already in UTF-8 the ``iconv`` function breaks it.